### PR TITLE
Revert "Update dependency jdx/rtx to v2024.1.0"

### DIFF
--- a/private_dot_config/private_aqua/aqua.yaml.tmpl
+++ b/private_dot_config/private_aqua/aqua.yaml.tmpl
@@ -14,7 +14,7 @@ packages:
 - name: BurntSushi/ripgrep@14.0.3
 - name: charmbracelet/glow@v1.5.1
 - name: direnv/direnv@v2.33.0
-- name: jdx/rtx@v2024.1.0
+- name: jdx/rtx@v2024.0.0
 - name: jesseduffield/lazygit@v0.40.2
 - name: helm/helm@v3.13.3
 - name: helmfile/helmfile@v0.160.0


### PR DESCRIPTION
Reverts mab/dotfiles#130

```
FATA[0000] aqua failed                                   aqua_version=2.21.0 env=darwin/arm64 error="install the package: the asset isn't found: rtx-v2024.1.0-macos-arm64.tar.gz" exe_name=rtx package_name=jdx/rtx package_version=v2024.1.0 program=aqua
```